### PR TITLE
not necessary disable dataProvider->sort

### DIFF
--- a/widgets/BaseTreeGrid.php
+++ b/widgets/BaseTreeGrid.php
@@ -403,7 +403,6 @@ abstract class BaseTreeGrid extends Widget {
 	protected function initDataProvider()
 	{
 		$this->dataProvider->pagination = false;
-		$this->dataProvider->sort = false;
 		if ($this->dataProvider instanceof ActiveDataProvider) {
 			$this->initActiveDataProvider();
 		}


### PR DESCRIPTION
why display dataProvider->sort?
if it disable we only can use:
```
$dataProvider = new ActiveDataProvider([
            'query' => BackendMenu::find()->orderBy(['sort' => SORT_ASC, 'id' => SORT_ASC]),
]);
````
but  usually we use in this way：
````
$dataProvider = new ActiveDataProvider([
            'query' => BackendMenu::find(),
            'sort' => ['defaultOrder' => ['sort' => SORT_ASC, 'id' => SORT_ASC]]
]);
````